### PR TITLE
Rename customHost to host

### DIFF
--- a/.changeset/rich-pots-explode.md
+++ b/.changeset/rich-pots-explode.md
@@ -1,0 +1,5 @@
+---
+"@baseplate-sdk/utils": major
+---
+
+Rename customHost to host

--- a/src/orgSettings.ts
+++ b/src/orgSettings.ts
@@ -38,7 +38,7 @@ interface StaticFileSettings {
 
 export interface StaticFileProxySettings {
   useBaseplateHosting: boolean;
-  customHost: string;
+  host: string;
 }
 
 export interface OrgSettings {


### PR DESCRIPTION
`customHost` didn't make much sense, since all environments have to have a host, including those that are hosted by us.