### PR TITLE
Implement mergeDefaultHtmlParams function

### DIFF
--- a/.changeset/light-dodos-behave.md
+++ b/.changeset/light-dodos-behave.md
@@ -1,0 +1,5 @@
+---
+"@baseplate-sdk/utils": minor
+---
+
+Implement mergeDefaultHtmlParams function

--- a/.changeset/violet-boats-tap.md
+++ b/.changeset/violet-boats-tap.md
@@ -1,0 +1,5 @@
+---
+"@baseplate-sdk/utils": patch
+---
+
+Add typings for CustomDomain values in KV storage

--- a/src/__snapshots__/htmlParams.test.ts.snap
+++ b/src/__snapshots__/htmlParams.test.ts.snap
@@ -5,12 +5,15 @@ Object {
   "headScripts": Array [],
   "headStylesheets": Array [],
   "importMap": Object {
-    "entryModule": "root-config",
     "name": "systemjs",
     "type": "systemjs",
     "useOverrides": true,
   },
   "lang": "en",
+  "pageInit": Object {
+    "layoutTemplate": "<routes></routes>",
+    "type": "single-spa",
+  },
   "pageTitle": "Web App",
   "preloads": Array [],
 }

--- a/src/__snapshots__/htmlParams.test.ts.snap
+++ b/src/__snapshots__/htmlParams.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`htmlParams matches snapshot for default params 1`] = `
+Object {
+  "headScripts": Array [],
+  "headStylesheets": Array [],
+  "importMap": Object {
+    "entryModule": "root-config",
+    "name": "systemjs",
+    "type": "systemjs",
+    "useOverrides": true,
+  },
+  "lang": "en",
+  "pageTitle": "Web App",
+  "preloads": Array [],
+}
+`;

--- a/src/__snapshots__/htmlParams.test.ts.snap
+++ b/src/__snapshots__/htmlParams.test.ts.snap
@@ -11,7 +11,7 @@ Object {
   },
   "lang": "en",
   "pageInit": Object {
-    "layoutTemplate": "<routes></routes>",
+    "layoutTemplate": "<single-spa-router></single-spa-router>",
     "type": "single-spa",
   },
   "pageTitle": "Web App",

--- a/src/customDomains.ts
+++ b/src/customDomains.ts
@@ -1,0 +1,15 @@
+// This is the JSON stored in Cloudflare KV Storage
+// under the `custom-domain-${hostname}` key. It helps
+// baseplate-cloudflare-worker know how to respond to
+// requests that originate from Baseplate custom domains
+export interface CustomDomain {
+  orgKey: string;
+  purpose: CustomDomainPurpose;
+  customerEnv?: string;
+  webAppHtmlFilename?: string;
+}
+
+export enum CustomDomainPurpose {
+  cdn_proxy = "cdn_proxy",
+  web_app = "web_app",
+}

--- a/src/htmlParams.test.ts
+++ b/src/htmlParams.test.ts
@@ -1,0 +1,45 @@
+import { HTMLTemplateParams, mergeDefaultHtmlParams } from "./htmlParams.js";
+import { RecursivePartial } from "./utils.js";
+
+describe(`htmlParams`, () => {
+  it(`matches snapshot for default params`, () => {
+    const params = mergeDefaultHtmlParams({});
+    expect(params).toMatchSnapshot();
+  });
+
+  it(`merges top level properties`, () => {
+    const params: RecursivePartial<HTMLTemplateParams> = {
+      lang: "es",
+      pageTitle: "Aplicacion de Web",
+      preloads: [
+        {
+          importSpecifier: "root-config",
+          as: "script",
+        },
+      ],
+    };
+    const finalParams = mergeDefaultHtmlParams(params);
+    expect(finalParams.lang).toBe(params.lang);
+    expect(finalParams.pageTitle).toBe(params.pageTitle);
+    expect(finalParams.preloads).toEqual(params.preloads);
+  });
+
+  it(`merges import map properties`, () => {
+    const params: RecursivePartial<HTMLTemplateParams> = {
+      importMap: {
+        name: "main",
+        useOverrides: false,
+        entryModule: "@convex/root-config",
+      },
+    };
+    const finalParams = mergeDefaultHtmlParams(params);
+    expect(finalParams.importMap.type).toBe("systemjs");
+    expect(finalParams.importMap.name).toBe(params.importMap!.name);
+    expect(finalParams.importMap.useOverrides).toBe(
+      params.importMap!.useOverrides
+    );
+    expect(finalParams.importMap.entryModule).toBe(
+      params.importMap!.entryModule
+    );
+  });
+});

--- a/src/htmlParams.test.ts
+++ b/src/htmlParams.test.ts
@@ -29,7 +29,6 @@ describe(`htmlParams`, () => {
       importMap: {
         name: "main",
         useOverrides: false,
-        entryModule: "@convex/root-config",
       },
     };
     const finalParams = mergeDefaultHtmlParams(params);
@@ -37,9 +36,6 @@ describe(`htmlParams`, () => {
     expect(finalParams.importMap.name).toBe(params.importMap!.name);
     expect(finalParams.importMap.useOverrides).toBe(
       params.importMap!.useOverrides
-    );
-    expect(finalParams.importMap.entryModule).toBe(
-      params.importMap!.entryModule
     );
   });
 });

--- a/src/htmlParams.ts
+++ b/src/htmlParams.ts
@@ -11,7 +11,7 @@ const defaultParams: HTMLTemplateParams = {
   },
   pageInit: {
     type: "single-spa",
-    layoutTemplate: "<routes></routes>",
+    layoutTemplate: "<single-spa-router></single-spa-router>",
   },
   preloads: [],
   headScripts: [],

--- a/src/htmlParams.ts
+++ b/src/htmlParams.ts
@@ -8,7 +8,10 @@ const defaultParams: HTMLTemplateParams = {
     type: "systemjs",
     name: "systemjs",
     useOverrides: true,
-    entryModule: "root-config",
+  },
+  pageInit: {
+    type: "single-spa",
+    layoutTemplate: "<routes></routes>",
   },
   preloads: [],
   headScripts: [],
@@ -37,11 +40,23 @@ export interface HTMLTemplateParams {
     type: "systemjs" | "native";
     name: string;
     useOverrides: boolean;
-    entryModule: string;
   };
+  pageInit: HTMLPageInit;
   preloads: HTMLPreload[];
   headScripts: HTMLScript[];
   headStylesheets: HTMLStylesheet[];
+}
+
+export type HTMLPageInit = ModulePageInit | SingleSpaPageInit;
+
+export interface ModulePageInit {
+  type: "module";
+  entryModule: string;
+}
+
+export interface SingleSpaPageInit {
+  type: "single-spa";
+  layoutTemplate: string;
 }
 
 export interface HTMLPreload {

--- a/src/htmlParams.ts
+++ b/src/htmlParams.ts
@@ -1,0 +1,61 @@
+import { mergeWith } from "lodash-es";
+import { RecursivePartial } from "./utils.js";
+
+const defaultParams: HTMLTemplateParams = {
+  lang: "en",
+  pageTitle: "Web App",
+  importMap: {
+    type: "systemjs",
+    name: "systemjs",
+    useOverrides: true,
+    entryModule: "root-config",
+  },
+  preloads: [],
+  headScripts: [],
+  headStylesheets: [],
+};
+
+export function mergeDefaultHtmlParams(
+  htmlParams: RecursivePartial<HTMLTemplateParams>
+): HTMLTemplateParams {
+  const finalSettings: HTMLTemplateParams = mergeWith(
+    {},
+    defaultParams,
+    htmlParams,
+    (newValue, oldValue) => {
+      return oldValue === null ? newValue : undefined;
+    }
+  );
+
+  return finalSettings;
+}
+
+export interface HTMLTemplateParams {
+  lang: string;
+  pageTitle: string;
+  importMap: {
+    type: "systemjs" | "native";
+    name: string;
+    useOverrides: boolean;
+    entryModule: string;
+  };
+  preloads: HTMLPreload[];
+  headScripts: HTMLScript[];
+  headStylesheets: HTMLStylesheet[];
+}
+
+export interface HTMLPreload {
+  importSpecifier?: string;
+  href?: string;
+  as: string;
+}
+
+export interface HTMLScript {
+  src: string;
+  async: boolean;
+  defer: boolean;
+}
+
+export interface HTMLStylesheet {
+  href: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,3 +4,11 @@ export {
   StaticFileProxySettings,
   CORSSettings,
 } from "./orgSettings.js";
+
+export {
+  mergeDefaultHtmlParams,
+  HTMLTemplateParams,
+  HTMLPreload,
+  HTMLScript,
+  HTMLStylesheet,
+} from "./htmlParams.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,3 +12,5 @@ export {
   HTMLScript,
   HTMLStylesheet,
 } from "./htmlParams.js";
+
+export { CustomDomain, CustomDomainPurpose } from "./customDomains.js";

--- a/src/orgSettings.ts
+++ b/src/orgSettings.ts
@@ -1,4 +1,5 @@
 import { mergeWith } from "lodash-es";
+import { RecursivePartial } from "./utils.js";
 
 const defaultSettings: OrgSettings = {
   staticFiles: {
@@ -83,12 +84,3 @@ export interface CustomDomainSettings {
   customCDNTestCloudflareIdentifier?: string;
   customCDNProdCloudflareIdentifier?: string;
 }
-
-// https://stackoverflow.com/questions/41980195/recursive-partialt-in-typescript
-type RecursivePartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? RecursivePartial<U>[]
-    : T[P] extends object
-    ? RecursivePartial<T[P]>
-    : T[P];
-};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+// https://stackoverflow.com/questions/41980195/recursive-partialt-in-typescript
+export type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object
+    ? RecursivePartial<T[P]>
+    : T[P];
+};


### PR DESCRIPTION
HTML params are used when baseplate-cloudflare-worker renders HTML files to host web apps / root configs. These params will be configurable within baseplate-web-app.